### PR TITLE
added php5-curl for Social Connect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
      && apt-get install apache2 libapache2-mod-php5 -yy \
      && apt-get install -yy php5-mysql imagemagick wget unzip \
      && apt-get install -yy php5-gd php5-ffmpeg dcraw mediainfo ffmpeg \
+     && apt-get install -yy php5-curl \
      && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN wget -q -O piwigo.zip http://piwigo.org/download/dlcounter.php?code=2.9.0 && \


### PR DESCRIPTION
Suggestion to add php5-curl to the image in order to support mistic100's Social Connect plug-in
[Social Connect](http://piwigo.org/ext/extension_view.php?eid=684)

Successful docker build and deployment at [my Piwigo gallery](https://photos.moonlightrambler.net
), so it should be good to merge