### PR TITLE
Method to add/override PHP configuration from files in mounted volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,12 +38,12 @@ RUN mv /var/www/themes /template/
 RUN mv /var/www/plugins /template/
 RUN mv /var/www/local /template/
 
-
-RUN mkdir -p /var/www/_data/i
+RUN mkdir -p /var/www/_data/i /config
 RUN chown -R www-data:www-data /var/www
 
-VOLUME ["/var/www/galleries", "/var/www/themes", "/var/www/plugins", "/var/www/local", "/var/www/_data/i"]
+VOLUME ["/var/www/galleries", "/var/www/themes", "/var/www/plugins", "/var/www/local", "/var/www/_data/i" "/config"]
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT /entrypoint.sh
 EXPOSE 80
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,9 +5,15 @@ for d in $(ls /template); do
 
 done
 
+mkdir -pv /config/php/apache2.d
+find /config/php/apache2.d -type f | while read file; do
+	ln -svf "${file}" "/etc/php/7.0/apache2/conf.d/$(basename "${file}")";
+done;
+
 sed -i "s/\/var\/www\/html/\/var\/www/g"  /etc/apache2/sites-enabled/000-default.conf
 
 chown -R www-data:www-data /var/www
 
 source /etc/apache2/envvars
 apache2ctl -D FOREGROUND
+


### PR DESCRIPTION
Specifically, my use case is to enable displaying errors (temporarily) and increase the max execution time (probably not temporarily)