### PR TITLE
Update to Piwigo 2.9.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Mathieu Ruellan <mathieu.ruellan@gmail.com>
 ENV DEBIAN_FRONTEND noninteractive
 ENV HOME /root
 
-ARG PIWIGO_VERSION="2.9.2"
+ARG PIWIGO_VERSION="2.9.3"
 
 RUN apt-get update \
      && apt-get install -yy \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Data must be stored on a volume.
 
 ## Changes
 - Upgrade to debian:stretch 
-- Upgrade to Piwigo 2.9.2
+- Upgrade to Piwigo 2.9.3
 
 ## Deployment
 


### PR DESCRIPTION
Please, when you push the new docker image, can you add additional tag?

Something like 2.9.3_b1 (piwigo 2.9.3 build 1)

That can help some people for container upgrade management.

Thanks