### PR TITLE
Remove second mediainfo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,7 @@ RUN apt update -y \
             ffmpeg\
             imagemagick \
             wget \
-            unzip \            
-            mediainfo \
+            unzip \
             exiftool \
      && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Hi! It seems `mediainfo` is specified twice in the list of packages to install with `apt-get`. This PR removes the second.