### PR TITLE
(re-) enable uploading by increasing nginx limit on client_body_size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -140,6 +140,8 @@ server {
 
     root /var/www;
 
+    client_max_body_size 100m;
+
     location ~ \.php\$ {
         try_files \$uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)\$;


### PR DESCRIPTION
nginx enforces client_max_body_size (default: 1 MiB), which is too small for a large set of photos to be uploaded. This leads to failure to upload a larger set of photos via app or web-upload.

Increasing client_max_body_size to 100m in nginx.conf fixes this issue.
